### PR TITLE
Add PingsControllerV1 unit tests

### DIFF
--- a/Temporal.Jumpstart.sln
+++ b/Temporal.Jumpstart.sln
@@ -74,6 +74,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Onboardings.Workers", "src\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Onboardings.Domain.Tests", "tests\Onboardings\Onboardings.Domain.Tests\Onboardings.Domain.Tests.csproj", "{98E58234-A9CA-4C1D-8294-7FAD8B5804C0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Onboardings.Api.Tests", "tests\Onboardings\Onboardings.Api.Tests\Onboardings.Api.Tests.csproj", "{017F5E9B-7F87-4592-8F35-9B0690F73D29}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Onboardings.Generated", "src\Onboardings\Onboardings.Generated\Onboardings.Generated.csproj", "{ADCA9D65-4BDC-480B-8005-204AC617D72A}"
 EndProject
 Global
@@ -234,6 +236,10 @@ Global
 		{98E58234-A9CA-4C1D-8294-7FAD8B5804C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{98E58234-A9CA-4C1D-8294-7FAD8B5804C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{98E58234-A9CA-4C1D-8294-7FAD8B5804C0}.Release|Any CPU.Build.0 = Release|Any CPU
+                {017F5E9B-7F87-4592-8F35-9B0690F73D29}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {017F5E9B-7F87-4592-8F35-9B0690F73D29}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {017F5E9B-7F87-4592-8F35-9B0690F73D29}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {017F5E9B-7F87-4592-8F35-9B0690F73D29}.Release|Any CPU.Build.0 = Release|Any CPU
 		{ADCA9D65-4BDC-480B-8005-204AC617D72A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{ADCA9D65-4BDC-480B-8005-204AC617D72A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ADCA9D65-4BDC-480B-8005-204AC617D72A}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/tests/Onboardings/Onboardings.Api.Tests/ConsoleWriter.cs
+++ b/tests/Onboardings/Onboardings.Api.Tests/ConsoleWriter.cs
@@ -1,0 +1,19 @@
+using Xunit.Abstractions;
+
+namespace Onboardings.Api.Tests;
+
+public class ConsoleWriter : StringWriter
+{
+    private ITestOutputHelper _output;
+
+    public ConsoleWriter(ITestOutputHelper output)
+    {
+        this._output = output;
+    }
+
+    public override void WriteLine(string? value)
+    {
+        _output.WriteLine(value);
+    }
+}
+

--- a/tests/Onboardings/Onboardings.Api.Tests/GlobalUsings.cs
+++ b/tests/Onboardings/Onboardings.Api.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/tests/Onboardings/Onboardings.Api.Tests/Onboardings.Api.Tests.csproj
+++ b/tests/Onboardings/Onboardings.Api.Tests/Onboardings.Api.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
+    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Onboardings\Onboardings.Api\Onboardings.Api.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Onboardings/Onboardings.Api.Tests/PingsControllerV1Tests.cs
+++ b/tests/Onboardings/Onboardings.Api.Tests/PingsControllerV1Tests.cs
@@ -1,0 +1,70 @@
+using System.Linq.Expressions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Moq;
+using Onboardings.Api.Controllers;
+using Onboardings.Api.Messages;
+using Onboardings.Domain.Clients.Temporal;
+using Onboardings.Domain.Workflows;
+using Temporalio.Client;
+
+namespace Onboardings.Api.Tests.Controllers;
+
+public class PingsControllerV1Tests : TestBase
+{
+    private readonly DefaultHttpContext _context;
+    private readonly Mock<ITemporalClient> _clientMock;
+    private readonly PingsControllerV1 _controller;
+
+    public PingsControllerV1Tests(ITestOutputHelper output) : base(output)
+    {
+        _context = new DefaultHttpContext();
+        _context.Request.Scheme = "http";
+        _context.Request.Host = new HostString("localhost");
+        _clientMock = new Mock<ITemporalClient>(MockBehavior.Strict);
+        _context.Features.Set<ITemporalClient>(_clientMock.Object);
+        var accessor = new HttpContextAccessor { HttpContext = _context };
+        var cfg = new TemporalConfig
+        {
+            Worker = new WorkerConfig { TaskQueue = "test" },
+            Connection = new ConnectionConfig("default", "localhost")
+        };
+        var options = Options.Create(cfg);
+        _controller = new PingsControllerV1(accessor, options, LoggerFactory)
+        {
+            ControllerContext = new ControllerContext { HttpContext = _context }
+        };
+    }
+
+    [Fact]
+    public async Task PutPingAsync_ReturnsAccepted()
+    {
+        _clientMock
+            .Setup(c => c.StartWorkflowAsync<Ping>(It.IsAny<Expression<Func<Ping, Task>>>(), It.IsAny<WorkflowOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Mock.Of<WorkflowHandle>());
+
+        var result = await _controller.PutPingAsync("ping1", new PutPing("hi"));
+
+        var accepted = Assert.IsType<AcceptedResult>(result);
+        Assert.Equal("http://localhost/v1/pings/ping1", accepted.Location);
+    }
+
+    [Fact]
+    public async Task GetOnboardingStatus_ReturnsOk()
+    {
+        var handleMock = new Mock<WorkflowHandle>();
+        handleMock
+            .Setup(h => h.QueryAsync<string>(It.IsAny<Expression<Func<Ping, string>>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("pong");
+        _clientMock
+            .Setup(c => c.GetWorkflowHandle<Ping>("ping1", null))
+            .Returns(handleMock.Object);
+
+        var result = await _controller.GetOnboardingStatus("ping1");
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.Equal("pong", ok.Value);
+    }
+}

--- a/tests/Onboardings/Onboardings.Api.Tests/TestBase.cs
+++ b/tests/Onboardings/Onboardings.Api.Tests/TestBase.cs
@@ -1,0 +1,40 @@
+namespace Onboardings.Api.Tests;
+
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+
+public abstract class TestBase : IDisposable
+{
+    private readonly TextWriter? _consoleWriter;
+
+    protected TestBase(ITestOutputHelper output)
+    {
+        LoggerFactory = Microsoft.Extensions.Logging.LoggerFactory.Create(builder =>
+            builder.AddXUnit(output));
+        // Only set this if not in-proc
+        _consoleWriter = new ConsoleWriter(output);
+        Console.SetOut(_consoleWriter);
+    }
+
+    ~TestBase()
+    {
+        Dispose(false);
+    }
+
+    protected ILoggerFactory LoggerFactory { get; private init; }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _consoleWriter?.Dispose();
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add API-level tests for `PingsControllerV1`
- wire `Onboardings.Api.Tests` project into the solution
- fix newline endings in test utilities

## Testing
- `dotnet test tests/Onboardings/Onboardings.Api.Tests/Onboardings.Api.Tests.csproj -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684a08ce9f608327aea3c252eaabbaad